### PR TITLE
Listen to all the clients

### DIFF
--- a/start-firestore
+++ b/start-firestore
@@ -10,4 +10,4 @@ fi
 gcloud config set project ${FIRESTORE_PROJECT_ID}
 
 # Start emulator
-gcloud beta emulators firestore start --host-port=localhost:8080
+gcloud beta emulators firestore start --host-port=0.0.0.0:8080


### PR DESCRIPTION
Some people need the emulator to be accessible from any client IP, not only 127.0.0.1 (localhost)

For example, consider this docker-compose.yml

```
services:
 firestore:
    image: perrystallings/cloud-firestore-emulator
    environment:
      - FIRESTORE_PROJECT_ID=local
    restart: unless-stopped
  php:
    image: php
    environment:
      FIRESTORE_PROJECT_ID: local
      FIRESTORE_EMULATOR_HOST: firestore:8080
    depends_on:
      - firestore
    links:
      - firestore
    restart: unless-stopped
```

When php requests the firestore, it has a docker internal network IP that is not localhost. And if you don't tell the firestore-emulator to listen to 0.0.0.0, it will reject any connection that does not come from 127.0.0.1